### PR TITLE
ACCESS_MOCK_LOCATION を debug/AndroidManifest.xml に追加

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.ikemura.android_kotlin_lab"
+    >
+
+    <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION" />
+
+</manifest>


### PR DESCRIPTION
## やったこと
ACCESS_MOCK_LOCATIONを追加してみた


<img src=https://user-images.githubusercontent.com/8417910/110557879-c5da0d00-8184-11eb-968e-b9c3204c0c6a.png  width=50%>

<img src=https://user-images.githubusercontent.com/8417910/110557872-c1adef80-8184-11eb-868d-cd30f5c92e1b.png  width=50%>

うまくMock Locationアプリとして認識できた

## 懸念点
IDEで ACCESS_MOCK_LOCATION が認識されない。。。

![image](https://user-images.githubusercontent.com/8417910/110558002-08034e80-8185-11eb-9b63-78ee4dd088a5.png)
しかしビルドは成功する 🤔 
あまり使わないほうがいいかもしれない